### PR TITLE
Simpler error for invalid yaml

### DIFF
--- a/bia_agent/rembi.py
+++ b/bia_agent/rembi.py
@@ -2,6 +2,8 @@ from typing import Dict
 
 from pydantic import BaseModel
 from ruamel.yaml import YAML
+from ruamel.yaml.scanner import ScannerError
+from ruamel.yaml.parser import ParserError
 from bia_rembi_models.study import Study
 from bia_rembi_models.sample import Biosample
 from bia_rembi_models.specimen import Specimen
@@ -29,7 +31,12 @@ class REMBIContainer(BaseModel):
 
 def parse_yaml(fpath):
     yaml = YAML()
-    with open(fpath) as fh:
-        raw_object = yaml.load(fh)
+
+    try:
+        with open(fpath) as fh:
+            raw_object = yaml.load(fh)
+    except (ScannerError, ParserError) as e:
+        exit(f"Invalid YAML: {str(e)}")
+
 
     return REMBIContainer.parse_obj(raw_object)

--- a/bia_agent/submission.py
+++ b/bia_agent/submission.py
@@ -4,6 +4,8 @@ from typing import Dict, Optional
 
 from pydantic import BaseModel, Field
 from ruamel.yaml import YAML
+from ruamel.yaml.scanner import ScannerError
+from ruamel.yaml.parser import ParserError
 
 from .files import FileCollection
 from .rembi2pagetab import rembi_container_to_pagetab
@@ -53,8 +55,11 @@ def submission_from_dirpath(submission_dirpath: pathlib.Path):
 
     yaml = YAML()
 
-    with open(submission_file_fpath) as fh:
-        raw_object = yaml.load(fh)
+    try:
+        with open(submission_file_fpath) as fh:
+            raw_object = yaml.load(fh)
+    except (ScannerError, ParserError) as e:
+        exit(f"Invalid YAML: {str(e)}")
 
     bia_submission = BIASubmission.parse_obj(raw_object)
     bia_submission.submission_dirpath = submission_dirpath


### PR DESCRIPTION
Got confused by errors like (below) when trying to convert invalid yaml. The behaviour now is to just print an error similar to `Invalid YAML: mapping values are not allowed here in "examples/rembi-metadata.yaml", line 45, column 19` and exit

```
(stacktrace above)
  File "/home/liviu/Documents/bia-agent/.venv/lib/python3.10/site-packages/ruamel/yaml/scanner.py", line 1770, in _gather_comments
    self.fetch_more_tokens()

  File "/home/liviu/Documents/bia-agent/.venv/lib/python3.10/site-packages/ruamel/yaml/scanner.py", line 276, in fetch_more_tokens
    return self.fetch_value()

  File "/home/liviu/Documents/bia-agent/.venv/lib/python3.10/site-packages/ruamel/yaml/scanner.py", line 626, in fetch_value
    raise ScannerError(

ruamel.yaml.scanner.ScannerError: mapping values are not allowed here
  in "examples/rembi-metadata.yaml", line 45, column 19
```
,  
```
(stacktrace above)
  File "/home/liviu/Documents/bia-agent/.venv/lib/python3.10/site-packages/ruamel/yaml/parser.py", line 139, in check_event
    self.current_event = self.state()

  File "/home/liviu/Documents/bia-agent/.venv/lib/python3.10/site-packages/ruamel/yaml/parser.py", line 603, in parse_block_mapping_key
    raise ParserError(

ruamel.yaml.parser.ParserError: while parsing a block mapping
  in "../wip_tickets/segmented_files/metadata_wip.yaml", line 67, column 3
expected <block end>, but found '<block mapping start>'
  in "../wip_tickets/segmented_files/metadata_wip.yaml", line 68, column 5
  ```