### PR TITLE
Update section names with enumerated suffix

### DIFF
--- a/bia_agent/mifa2pagetab.py
+++ b/bia_agent/mifa2pagetab.py
@@ -11,6 +11,7 @@ from .utils import (rembi_study_to_pagetab_submission,
                     analysis_to_pagetab_section,
                     study_component_to_pagetab_section,
                     mifa_annotations_to_pagetab_section,
+                    rembi_objects_to_pagetab_sections,
                     ST_MIFA_TEMPLATE_VERSION)
 
 def rembi_mifa_container_to_pagetab(container: REMBIContainer, accession_id: Optional[str], root_path: Optional[str]) -> Submission:
@@ -20,14 +21,6 @@ def rembi_mifa_container_to_pagetab(container: REMBIContainer, accession_id: Opt
 
     if root_path:
         submission.attributes.append(Attribute(name="RootPath", value=root_path))
-
-    def rembi_objects_to_pagetab_sections(conversion_func, objects_dict):
-
-        sections = [
-            conversion_func(object, title=object_id)
-            for object_id, object in objects_dict.items()
-        ]
-        return sections
 
     submission.section.subsections += rembi_objects_to_pagetab_sections(
         biosample_to_pagetab_section, container.biosamples
@@ -46,14 +39,14 @@ def rembi_mifa_container_to_pagetab(container: REMBIContainer, accession_id: Opt
     )
 
     ann_section = [
-        mifa_annotations_to_pagetab_section(ann_object, v_object, ann_id)
-        for (ann_id, ann_object),(v_id, v_object) in zip(container.annotations.items(),container.version.items())
+        mifa_annotations_to_pagetab_section(annotations=ann_object, version=v_object, title=ann_id, suffix=n)
+        for n, ((ann_id, ann_object),(v_id, v_object)) in enumerate(zip(container.annotations.items(),container.version.items()), start=1)
     ]
     submission.section.subsections += ann_section
 
     sc_section = [
-        study_component_to_pagetab_section(sc_object,a_object)
-        for (sc_id, sc_object),(a_id, a_object) in zip(container.study_component.items(),container.associations.items())
+        study_component_to_pagetab_section(study_component=sc_object, associations=a_object, suffix=n)
+        for n, ((sc_id, sc_object),(a_id, a_object)) in enumerate(zip(container.study_component.items(),container.associations.items()), start=1)
     ]
 
     submission.section.subsections += sc_section
@@ -68,17 +61,9 @@ def mifa_container_to_pagetab(container: REMBIContainer, accession_id: Optional[
     if root_path:
         submission.attributes.append(Attribute(name="RootPath", value=root_path))
 
-    def rembi_objects_to_pagetab_sections(conversion_func, objects_dict):
-
-        sections = [
-            conversion_func(object, object_id)
-            for object_id, object in objects_dict.items()
-        ]
-        return sections
-
     ann_section = [
-        mifa_annotations_to_pagetab_section(ann_object, v_object, ann_id)
-        for (ann_id, ann_object),(v_id, v_object) in zip(container.annotations.items(),container.version.items())
+        mifa_annotations_to_pagetab_section(annotations=ann_object, version=v_object, title=ann_id, suffix=n)
+        for n, ((ann_id, ann_object),(v_id, v_object)) in enumerate(zip(container.annotations.items(),container.version.items()), start=1)
     ]
     submission.section.subsections += ann_section
 

--- a/bia_agent/rembi2pagetab.py
+++ b/bia_agent/rembi2pagetab.py
@@ -9,6 +9,7 @@ from .utils import (rembi_study_to_pagetab_submission,
                     correlation_to_pagetab_section,
                     analysis_to_pagetab_section,
                     study_component_to_pagetab_section,
+                    rembi_objects_to_pagetab_sections,
                     ST_REMBI_TEMPLATE_VERSION)
 
 
@@ -20,13 +21,6 @@ def rembi_container_to_pagetab(container: REMBIContainer, accession_id: Optional
     if root_path:
         submission.attributes.append(Attribute(name="RootPath", value=root_path))
 
-    def rembi_objects_to_pagetab_sections(conversion_func, objects_dict):
-        sections = [
-            conversion_func(object, title=object_id)
-            for object_id, object in objects_dict.items()
-        ]
-
-        return sections
 
     submission.section.subsections += rembi_objects_to_pagetab_sections(
         biosample_to_pagetab_section, container.biosamples
@@ -45,8 +39,8 @@ def rembi_container_to_pagetab(container: REMBIContainer, accession_id: Optional
     )
 
     sc_section = [
-        study_component_to_pagetab_section(sc_object,a_object)
-        for (sc_id, sc_object),(a_id, a_object) in zip(container.study_component.items(),container.associations.items())
+        study_component_to_pagetab_section(sc_object, a_object, suffix=n)
+        for n, ((sc_id, sc_object),(a_id, a_object)) in enumerate(zip(container.study_component.items(),container.associations.items()), start=1)
     ]
 
     submission.section.subsections += sc_section

--- a/bia_agent/tests/test_cli.py
+++ b/bia_agent/tests/test_cli.py
@@ -1,28 +1,23 @@
 from typer.testing import CliRunner
 from bia_agent.cli import app
+from pathlib import Path
 import pytest
 runner = CliRunner()
 
-@pytest.mark.parametrize(
-    "rembi_file_path, accession_id",
-    [
-        ("examples/rembi-metadata.yaml", "S-BIADXX"),
-    ],
-)
-def test_rembi(rembi_file_path: str, accession_id: str):
-    result = runner.invoke(app, ["rembi-to-pagetab", rembi_file_path, accession_id])
-    assert result.exit_code == 0
-    assert result.stdout is not None  # Ensure some output is produced
-    
+ACCESSION_ID="S-BIADXXX"
 
 @pytest.mark.parametrize(
-    "rembi_file_path, accession_id",
+    "rembi_file_path, cli_command, outfile",
     [
-        ("examples/mifa-metadata.yaml","S-BIADXX"),
+        ("examples/rembi-metadata.yaml", "rembi-to-pagetab", "examples/output/rembi-metadata_rembi-to-pagetab.tsv"),
+        ("examples/mifa-metadata.yaml", "rembi-mifa-to-pagetab", "examples/output/mifa-metadata_rembi-mifa-to-pagetab.tsv"),
+        ("examples/rembi-metadata-with-mifa.yaml", "rembi-mifa-to-pagetab", "examples/output/rembi-metadata-with-mifa_rembi-mifa-to-pagetab.tsv")
     ],
 )
-def test_rembi_mifa_to_pagetab(rembi_file_path: str, accession_id: str):
-    result = runner.invoke(app, ["rembi-mifa-to-pagetab",
-                                 rembi_file_path,accession_id])
+def test_cli_stdout(rembi_file_path: str, cli_command: str, outfile: str):
+    
+    result = runner.invoke(app, [cli_command, rembi_file_path, ACCESSION_ID])
+
     assert result.exit_code == 0
     assert result.stdout is not None  # Ensure some output is produced
+    assert result.stdout == Path(outfile).read_text() #Veryify output is equal to files

--- a/bia_agent/utils.py
+++ b/bia_agent/utils.py
@@ -26,13 +26,10 @@ def append_if_not_none(attr_list, name, value):
 
 
 def generate_org_map(rembi_study):
-    organisations = set(author.affiliation for author in rembi_study.authors)
-    org_map = {
-        org: f"o{n}"
-        for n, org in enumerate(organisations, start=1)
-    }
-    
-    return org_map
+    organisations = dict.fromkeys(author.affiliation for author in rembi_study.authors)
+    for n, key in enumerate(organisations.keys(), start=1):
+        organisations[key] = f"o{n}"
+    return organisations
 
 
 def organisation_and_label_to_pagetab_section(org, org_label):

--- a/bia_agent/utils.py
+++ b/bia_agent/utils.py
@@ -505,3 +505,12 @@ def mifa_version_to_pagetab_section(version: Version) -> Section:
     append_if_not_none(version_section.attributes, "Previous version", version.previous_version)
 
     return version_section
+
+
+def rembi_objects_to_pagetab_sections(conversion_func, objects_dict):
+    sections = [
+        conversion_func(object, title=object_id, suffix=n)
+        for n, (object_id, object) in enumerate(objects_dict.items(), start=1)
+    ]
+
+    return sections

--- a/examples/output/mifa-metadata_rembi-mifa-to-pagetab.tsv
+++ b/examples/output/mifa-metadata_rembi-mifa-to-pagetab.tsv
@@ -1,0 +1,66 @@
+Submission	S-BIADXXX
+Title	An annotated fluorescence image dataset for training nuclear segmentation methods
+ReleaseDate	2024-08-02
+AttachTo	BioImages
+Template	BioImages.MIFA.v1
+REMBI_PageTab Conversion Script Version	1.0.0
+
+Study
+Description	This dataset contains annotated fluorescent nuclear images of normal or cancer cells from different tissue origins and sample preparation types,  and can be used to train machine-learning based nuclear image segmentation algorithms.
+It consists of 79 expert-annotated fluorescence images  of immuno and DAPI stained samples containing 7813 nuclei in total.
+In addition, the dataset is heterogenous in aspects such as type of preparation,  imaging modality, magnification, signal-to-noise ratio and other technical aspects.
+Relevant parameters, e.g. diagnosis, magnification,  signal-to-noise ratio and modality with respect to the type of preparation are provided in the file list.
+The images are derived from one Schwann cell stroma-rich tissue (from a ganglioneuroblastoma) cryosection (10 images/2773 nuclei), seven neuroblastoma (NB) patients (19 images/931 nuclei), one Wilms patient (1 image/102 nuclei),  two NB cell lines (CLB-Ma, STA-NB10) (8 images/1785 nuclei) and a human keratinocyte cell line (HaCaT) (41 images/2222 nuclei).
+Keyword	AI
+Keyword	segmentation
+Keyword	nucleus
+Keyword	fluorescence
+Acknowledgements	We thank Professor Josiah Carberry for useful discussions
+Funding statement	This work was facilitated by an EraSME grant (project TisQuant) under the grant no. 844198 and by a COIN grant (project VISIOMICS) under the grant no. 861750, both grants kindly provided by the Austrian Research Promotion Agency (FFG), and the St. Anna Kinderkrebsforschung.  Partial funding was further provided by BMK, BMDW, and the Province of Upper Austria in the frame of the COMET Programme managed by FFG.
+
+Link	https://github.com/perlfloccri/NuclearSegmentationPipeline
+Description	Deep Learning models trained with this dataset
+
+author
+Name	Sabine Taschner-Mandl
+E-mail	sabine.taschner@ccri.at
+Role	conceptualization, data acquisition
+ORCID	0000-0002-1439-5301
+<affiliation>	o1
+
+author
+Name	Florian Kromp
+Role	conceptualization, data acquisition, data annotation, data analysis
+ORCID	0000-0003-4557-5652
+<affiliation>	o1
+
+organization	o1
+Name	Children's Cancer Research Institute
+Address	Zimmermannplatz 10, 1090 Vienna, Austria
+
+Publication
+Title	An annotated fluorescence image dataset for training nuclear segmentation methods
+Year	2020
+Authors	Florian Kromp, Eva Bozsaky, Fikret Rifatbegovic, Lukas Fischer, Magdalena Ambros, Maria Berneder,  Tamara Weiss, Daria Lazic, Wolfgang Dörr, Allan Hanbury, Klaus Beiske, Peter F. Ambros, Inge M. Ambros & Sabine Taschner-Mandl
+DOI	https://doi.org/10.1038/s41597-020-00608-w
+PMC ID	PMC7419523
+
+Funding
+Agency	EraSME
+grant_id	844198
+
+Annotations	Annotations-1
+Title	Segmentation masks
+Annotation Overview	Segmentations masks of human cell nuclei curated by experts from a model prediction
+Annotation Type	segmentation_mask
+Annotation Method	Nuclei image annotation was performed by students and expert biologists trained by a disease expert.  To accelerate the time consuming process of image annotation, a machine learning-based framework (MLF) was utilized supporting  the process of annotation by learning characteristics of annotation in multiple steps. The MLF annotations result in a coarse annotation  of nuclear contours and have to be refined to serve as ground truth annotation. Therefore, annotated images were exported as  support vector graphic (SVG) files and imported into Adobe Illustrator (AI) CS6. AI enables the visualization of annotated nuclei as polygons  overlaid on the raw nuclear image and provides tools to refine the contours of each nucleus. An expert biologist and disease expert carefully curated  all images by refining polygonal contours and by removing polygons or adding them, if missing. Finally, an expert pathologist was consulted  to revise all image annotations and annotations were curated according to the pathologist's suggestions. In cases where decision finding was difficult,  a majority vote including all experts' suggestions was considered and annotations were corrected accordingly.  Images were exported and converted to Tagged Image File Format (TIFF) files, serving as nuclear masks in the ground truth dataset.  To set a baseline for machine learning-based image segmentation methods and to validate the proposed dataset, 25 nuclei were randomly sampled from  the ground truth annotations for each of the classes, marked on the raw images and presented to two independent experts for image annotation.  Annotation was carried out by a biology expert with long-standing experience in nuclear image annotation, further called annotation expert, and a biologist  with experience in cell morphology and microscopy, further called expert biologist. Nuclei were annotated using SVG-files and Adobe illustrator.  The single-nuclei annotations, described as single-cell annotations within the dataset, can be downloaded along with the dataset.
+Annotation Confidence Level	Curators had between 10 and 15 years of experience in cancer pathology
+Annotation Criteria	"The annotation of nuclei in tissue sections or tumor touch imprints is challenging and may not be unambiguous due to out-of-focus light or nuclei,  damaged nuclei or nuclei presenting with modified morphology due to the slide preparation procedure. We defined the following criteria to annotate  nuclear images: Only intact nuclei are annotated, even if the nuclear intensity is low in comparison to all other nuclei present. Nuclei have to be in focus.  If parts of a nucleus are out of focus, only the part of the nucleus being in focus is annotated. Nuclear borders have to be annotated as exact as resolution  and blurring allows for. Nuclei are not annotated if their morphology was heavily changed due to the preparation procedure.  Nuclei from dividing cells are annotated as one nucleus unless clear borders can be distinguished between the resulting new nuclei."
+Annotation Coverage	All the images in the dataset were annotated
+
+Version		Annotations-1
+Annotation version	v1.1
+Version timestamp	2015-03-22 01:49:21
+Version changes	The new version of the dataset includes 20 additional annotations (files seg34.tif to seg54.tif)
+Previous version	v1.0
+

--- a/examples/output/rembi-metadata-with-mifa_rembi-mifa-to-pagetab.tsv
+++ b/examples/output/rembi-metadata-with-mifa_rembi-mifa-to-pagetab.tsv
@@ -1,0 +1,114 @@
+Submission	S-BIADXXX
+Title	An annotated fluorescence image dataset for training nuclear segmentation methods
+ReleaseDate	2024-08-02
+AttachTo	BioImages
+Template	BioImages.MIFA.v1
+REMBI_PageTab Conversion Script Version	1.0.0
+
+Study
+Description	This dataset contains annotated fluorescent nuclear images of normal or cancer cells from different tissue origins and sample preparation types,  and can be used to train machine-learning based nuclear image segmentation algorithms. It consists of 79 expert-annotated fluorescence images  of immuno and DAPI stained samples containing 7813 nuclei in total. In addition, the dataset is heterogenous in aspects such as type of preparation,  imaging modality, magnification, signal-to-noise ratio and other technical aspects. Relevant parameters, e.g. diagnosis, magnification,  signal-to-noise ratio and modality with respect to the type of preparation are provided in the file list. The images are derived from one Schwann cell stroma-rich tissue (from a ganglioneuroblastoma) cryosection (10 images/2773 nuclei), seven neuroblastoma (NB) patients (19 images/931 nuclei), one Wilms patient (1 image/102 nuclei),  two NB cell lines (CLB-Ma, STA-NB10) (8 images/1785 nuclei) and a human keratinocyte cell line (HaCaT) (41 images/2222 nuclei).
+Keyword	AI
+Keyword	segmentation
+Keyword	nucleus
+Keyword	fluorescence
+Acknowledgements	We thank Professor Josiah Carberry for useful discussions
+Funding statement	This work was facilitated by an EraSME grant (project TisQuant) under the grant no. 844198 and by a COIN grant (project VISIOMICS) under the grant no. 861750, both grants kindly provided by the Austrian Research Promotion Agency (FFG), and the St. Anna Kinderkrebsforschung.  Partial funding was further provided by BMK, BMDW, and the Province of Upper Austria in the frame of the COMET Programme managed by FFG.
+
+Link	https://github.com/perlfloccri/NuclearSegmentationPipeline
+Description	Deep Learning models trained with this dataset
+
+author
+Name	Sabine Taschner-Mandl
+E-mail	sabine.taschner@ccri.at
+Role	conceptualization, data acquisition
+ORCID	0000-0002-1439-5301
+<affiliation>	o1
+
+author
+Name	Florian Kromp
+Role	conceptualization, data acquisition, data annotation, data analysis
+ORCID	0000-0003-4557-5652
+<affiliation>	o1
+
+organization	o1
+Name	Children's Cancer Research Institute
+Address	Zimmermannplatz 10, 1090 Vienna, Austria
+
+Publication
+Title	An annotated fluorescence image dataset for training nuclear segmentation methods
+Year	2020
+Authors	Florian Kromp, Eva Bozsaky, Fikret Rifatbegovic, Lukas Fischer, Magdalena Ambros, Maria Berneder,  Tamara Weiss, Daria Lazic, Wolfgang Dörr, Allan Hanbury, Klaus Beiske, Peter F. Ambros, Inge M. Ambros & Sabine Taschner-Mandl
+DOI	https://doi.org/10.1038/s41597-020-00608-w
+PMC ID	PMC7419523
+
+Funding
+Agency	EraSME
+grant_id	844198
+
+Biosample	Biosample-1
+Title	First biosample
+Biological entity	Schwann cell stroma-rich tissue from a patient with a ganglioneuroblastoma tumor
+Description	Tumor sample from ganglioneuroblastoma patient
+
+Organism	Organism-1	Biosample-1
+Scientific name	Homo sapiens
+Common name	human 
+NCBI taxon ID	NCBI:txid9606
+
+Specimen	Specimen-1
+Title	First specimen
+Sample Preparation Protocol	The fresh-frozen tumor tissues of one ganglioneuroblastoma patient, one neuroblastoma patient and one Wilms tumor patient were embedded into tissue-tek-OCT and 4 𝜇𝑚 thick cryosections were prepared. Sections were mounted on Histobond glass slides (Marienfeld), fixed in 4.5% formaledhyde and stained with 4,6-diamino-2-phenylindole (DAPI), a blue fluorescent dye conventionally used for staining of nuclei for cellular imaging techniques. Finally, slides were covered with Vectashield and coverslips were sealed on the slides with rubber cement.
+
+Image Acquisition	Image Acquisition-1
+Title	First acquisition
+Imaging Instrument	Leica Microsystems Stellaris 8 DIVE (Deep In-Vivo Explorer)
+Image Acquisition Parameters	Voxel size 0.0430x0.0430x0.5002 micron^3
+
+Imaging Method	Imaging Method-1	Image Acquisition-1
+Ontology Value	Confocal microscopy 
+Ontology Name	Biological Imaging Methods Ontology (FBbi)
+Ontology Term ID	http://purl.obolibrary.org/obo/FBbi_00000251 
+
+Image Acquisition	Image Acquisition-2
+Title	Second acquisition
+Imaging Instrument	Leica Microsystems Stellaris 8 DIVE (Deep In-Vivo Explorer)
+Image Acquisition Parameters	Voxel size 0.0430x0.0430x0.2985 micron^3 
+
+Imaging Method	Imaging Method-2	Image Acquisition-2
+Ontology Value	Multi-photon microscopy 
+Ontology Name	Biological Imaging Methods Ontology (FBbi)
+Ontology Term ID	http://purl.obolibrary.org/obo/FBbi_00000254
+
+Annotations	Annotations-1
+Title	Segmentation masks
+Annotation Overview	Segmentations masks of human cell nuclei curated by experts from a model prediction 
+Annotation Type	segmentation_mask
+Annotation Method	Nuclei image annotation was performed by students and expert biologists trained by a disease expert.  To accelerate the time consuming process of image annotation, a machine learning-based framework (MLF) was utilized supporting  the process of annotation by learning characteristics of annotation in multiple steps. The MLF annotations result in a coarse annotation  of nuclear contours and have to be refined to serve as ground truth annotation. Therefore, annotated images were exported as  support vector graphic (SVG) files and imported into Adobe Illustrator (AI) CS6. AI enables the visualization of annotated nuclei as polygons  overlaid on the raw nuclear image and provides tools to refine the contours of each nucleus. An expert biologist and disease expert carefully curated  all images by refining polygonal contours and by removing polygons or adding them, if missing. Finally, an expert pathologist was consulted  to revise all image annotations and annotations were curated according to the pathologist's suggestions. In cases where decision finding was difficult,  a majority vote including all experts' suggestions was considered and annotations were corrected accordingly.  Images were exported and converted to Tagged Image File Format (TIFF) files, serving as nuclear masks in the ground truth dataset.  To set a baseline for machine learning-based image segmentation methods and to validate the proposed dataset, 25 nuclei were randomly sampled from  the ground truth annotations for each of the classes, marked on the raw images and presented to two independent experts for image annotation.  Annotation was carried out by a biology expert with long-standing experience in nuclear image annotation, further called annotation expert, and a biologist  with experience in cell morphology and microscopy, further called expert biologist. Nuclei were annotated using SVG-files and Adobe illustrator.  The single-nuclei annotations, described as single-cell annotations within the dataset, can be downloaded along with the dataset.
+Annotation Confidence Level	Curators had between 10 and 15 years of experience in cancer pathology
+Annotation Criteria	The annotation of nuclei in tissue sections or tumor touch imprints is challenging and may not be unambiguous due to out-of-focus light or nuclei,  damaged nuclei or nuclei presenting with modified morphology due to the slide preparation procedure. We defined the following criteria to annotate  nuclear images: Only intact nuclei are annotated, even if the nuclear intensity is low in comparison to all other nuclei present. Nuclei have to be in focus.  If parts of a nucleus are out of focus, only the part of the nucleus being in focus is annotated. Nuclear borders have to be annotated as exact as resolution  and blurring allows for. Nuclei are not annotated if their morphology was heavily changed due to the preparation procedure.  Nuclei from dividing cells are annotated as one nucleus unless clear borders can be distinguished between the resulting new nuclei.
+Annotation Coverage	All the images in the dataset were annotated
+
+Version		Annotations-1
+Annotation version	v1.1
+Version timestamp	2015-03-22 01:49:21
+Version changes	The new version of the dataset includes 20 additional annotations (files seg34.tif to seg54.tif)
+Previous version	v1.0
+
+Study Component	Study Component-1
+Name	Confocal fluorescence images
+Description	Confocal fluorescence images of tumor sample from neuroblastoma patient
+
+Associations		Study Component-1
+Biosample	First biosample
+Specimen	First specimen
+Image acquisition	First acquisition
+
+Study Component	Study Component-2
+Name	Multi-photon fluorescence images
+Description	Multi-photon fluorescence images of tumor sample from neuroblastoma patient
+
+Associations		Study Component-2
+Biosample	First biosample
+Specimen	First specimen
+Image acquisition	Second acquisition
+

--- a/examples/output/rembi-metadata_rembi-to-pagetab.tsv
+++ b/examples/output/rembi-metadata_rembi-to-pagetab.tsv
@@ -1,0 +1,91 @@
+Submission	S-BIADXXX
+Title	Embryonic mice ultrasound volumes with body and brain volume segmentation masks
+ReleaseDate	2023-05-10
+AttachTo	BioImages
+Template	BioImages.v4
+REMBI_PageTab Conversion Script Version	1.0.0
+
+Study
+Description	A dataset consisting of 231 embryonic mice High Frequency Ultrasound volumes which were acquired in utero and in vivo from pregnant mice. Another submission contains the body and brain volume segmentation masks of these images.
+Keyword	Image segmentation
+Keyword	high-frequency ultrasound
+Keyword	mouse embryo
+Keyword	volumetric deep learning
+
+Link	https://www.ebi.ac.uk/biostudies/bioimages/studies/S-BSST401
+Description	Original submission (not curated)
+
+Link	https://github.com/BioImage-Archive
+Description	Github link for the Image Analysis
+
+author
+Name	Ziming Qiu
+Role	submitter
+<affiliation>	o1
+
+author
+Name	Matthew Hartley
+Role	data curator
+<affiliation>	o2
+
+organization	o1
+Name	Department of Electrical and Computer Engineering
+Address	New York University, New York, USA
+
+organization	o2
+Name	European Molecular Biology Laboratory, European Bioinformatics Institute
+Address	
+
+Publication
+Title	DEEP MOUSE: AN END-TO-END AUTO-CONTEXT REFINEMENT FRAMEWORK FOR BRAIN VENTRICLE & BODY SEGMENTATION IN EMBRYONIC MICE ULTRASOUND VOLUMES.
+Year	2020
+Authors	Qiu Z, Das W, Wang C, Langerman J, Nair N, Aristizábal O, Mamou J, Turnbull DH, Ketterling JA, Wang Y
+DOI	https://doi.org/10.1109/isbi45749.2020.9098387
+PMC ID	PMC7768981
+
+Biosample	Biosample-1
+Title	In utero mouse embryos
+Biological entity	mouse embryo volumes
+Description	mouse embryo volumes which were acquired in utero and in vivo from pregnant mice (10-14.5 days after mating)
+Intrinsic variable	Homozygous GFP integration into mitotic genes
+
+Organism	Organism-1	Biosample-1
+Scientific name	mus musculus
+Common name	mouse
+NCBI taxon ID	NCBI:txid10090
+
+Specimen	Specimen-1
+Title	HFU sample preparation
+Sample Preparation Protocol	Unknown
+
+Image Acquisition	Image Acquisition-1
+Title	Ultrasound Image Acquisition
+Imaging Instrument	High frequency ultrasound 5-element 40-MHz annular array
+Image Acquisition Parameters	The dimensions of the HFU volumes vary from 150 x 161 x 81 to 210 x 281 x 282 voxels and the voxel size is 50 x 50 x 50 μm
+
+Imaging Method	Imaging Method-1	Image Acquisition-1
+Ontology Value	Echography
+Ontology Name	EDAM
+Ontology Term ID	http://edamontology.org/topic_3954
+
+Image Correlation	Image Correlation-1
+Title	Image Correlation
+Spatial and temporal alignment	An alignment algorithm is used.
+Fiducials used	Fiducials were randomly dropped into sample
+Transformation matrix	Matrix is provided as a table.
+
+Image Analysis	Image-Analysis-1
+Title	Image Analysis
+Image Analysis Overview	Analysis is done with custom tensorflow models. The code is on github. Linked in Links field.
+
+Study Component	Study Component-1
+Name	Ultrasound images
+Description	Ultrasound images and correlation and analysis
+
+Associations		Study Component-1
+Biosample	In utero mouse embryos
+Specimen	HFU sample preparation
+Image acquisition	Ultrasound Image Acquisition
+Image Correlation	Image Correlation
+Image Analysis	Image Analysis
+


### PR DESCRIPTION
Contains 2 commits:

**Commit 1: add enumerated suffixes to section names**
- Moved rembi_objects_to_pagetab_sections into utils.py, since it was being defined in multiple places
- Made rembi_objects_to_pagetab_sections pass in the enumerated count of the object  into the conversion function, so the output looks as follow:
`Image Acquisition       Image Acquisition-1
Title   First acquisition
Imaging Instrument      Leica Microsystems Stellaris 8 DIVE (Deep In-Vivo Explorer)
Image Acquisition Parameters    Voxel size 0.0430x0.0430x0.5002 micron^3

Image Acquisition       Image Acquisition-2
Title   Second acquisition
Imaging Instrument      Leica Microsystems Stellaris 8 DIVE (Deep In-Vivo Explorer)
Image Acquisition Parameters    Voxel size 0.0430x0.0430x0.2985 micron^3 `
- Made similar updates add suffixes to mifa_annotations_to_pagetab_section and study_component_to_pagetab_section so they all get enumerated

**Commit 2: update to tests**
I wanted to update the tests to compare the stdout to a file so that future update we can update the expected output as a way to help document what our changes have done. So i made changes to the test logic and added files that contain the output that gets printed.

As part of this change i decided to change the generate_org_map function in utils: it was using an (unordered) set which created non-deterministic output that was a pain to account for in the tests. Since it was making an (ordered) dictionary anyway i tweaked the logic without changing the output so it would create an output with a consistent order.