### PR TITLE
cli parses json and converts to pagetab

### DIFF
--- a/bia_agent/cli.py
+++ b/bia_agent/cli.py
@@ -8,7 +8,7 @@ from .biostudies import Submission
 from .files import FileCollection
 from .submission import submission_from_dirpath, generate_bst_submission, generate_filelists
 from .transfer import copy_single_file, copy_all, verify
-from .rembi import parse_yaml
+from .rembi import parse
 from .rembi2pagetab import rembi_container_to_pagetab
 from .mifa2pagetab import rembi_mifa_container_to_pagetab, mifa_container_to_pagetab
 
@@ -121,7 +121,7 @@ def check_pagetab_json(json_fpath: pathlib.Path):
 
 @app.command()
 def rembi_to_pagetab(rembi_fpath: pathlib.Path, accession_id: str):
-    rembi_container = parse_yaml(rembi_fpath)
+    rembi_container = parse(rembi_fpath)
 
     bst_submission = rembi_container_to_pagetab(rembi_container, accession_id=accession_id, root_path=None)
 
@@ -129,14 +129,15 @@ def rembi_to_pagetab(rembi_fpath: pathlib.Path, accession_id: str):
 
 @app.command()
 def rembi_mifa_to_pagetab(rembi_mifa_fpath: pathlib.Path, accession_id: str):
-    rembi_mifa_container = parse_yaml(rembi_mifa_fpath)
+    rembi_mifa_container = parse(rembi_mifa_fpath)
+
     bst_submission = rembi_mifa_container_to_pagetab(rembi_mifa_container, accession_id=accession_id, root_path=None)
     
     print(bst_submission.as_tsv())
 
 @app.command()
 def mifa_to_pagetab(mifa_fpath: pathlib.Path, accession_id: str):
-    mifa_container = parse_yaml(mifa_fpath)
+    mifa_container = parse(mifa_fpath)
 
     bst_submission = mifa_container_to_pagetab(mifa_container, accession_id=accession_id, root_path=None)
     

--- a/bia_agent/rembi.py
+++ b/bia_agent/rembi.py
@@ -12,6 +12,8 @@ from bia_rembi_models.correlation import ImageCorrelation
 from bia_rembi_models.analysis import ImageAnalysis
 from bia_mifa_models.pydantic_model import Annotations, Version
 from bia_rembi_models.study_component import StudyComponent
+from pathlib import Path
+import json
 
 class REMBIAssociation(BaseModel):
     biosample_id: str
@@ -35,6 +37,20 @@ class REMBIContainer(BaseModel):
     study_component: Dict[str, StudyComponent] = {}
 
 
+def parse(fpath):
+    if not Path(fpath).is_file():
+        exit(f"{fpath} is not a file")
+
+    
+    match Path(fpath).suffix:
+        case '.json':
+            return parse_json(fpath)
+        case '.yaml':
+            return parse_yaml(fpath)
+        case _:
+            exit(f'{fpath} is not a json or yaml')
+
+            
 def parse_yaml(fpath):
     yaml = YAML()
 
@@ -44,5 +60,14 @@ def parse_yaml(fpath):
     except (ScannerError, ParserError) as e:
         exit(f"Invalid YAML: {str(e)}")
 
+    return REMBIContainer.parse_obj(raw_object)
+
+def parse_json(fpath):
+
+    try:
+        with open(fpath) as file:
+            raw_object = json.load(file)
+    except json.JSONDecodeError as e:
+        exit(f"Invalid JSON: {str(e)}")
 
     return REMBIContainer.parse_obj(raw_object)

--- a/bia_agent/submission.py
+++ b/bia_agent/submission.py
@@ -11,7 +11,7 @@ from .files import FileCollection
 from .rembi2pagetab import rembi_container_to_pagetab
 from .utils import (create_study_component,
                     create_annotations_section)
-from .rembi import parse_yaml
+from .rembi import parse
 
 
 logger = logging.getLogger("bia-agent")
@@ -86,7 +86,7 @@ def generate_filelists(bia_submission):
 
 
 def generate_bst_submission(bia_submission: BIASubmission, accession_id: Optional[str], skip_filelists: bool = False):
-    rembi_container = parse_yaml(bia_submission.submission_dirpath/"rembi-metadata.yaml")
+    rembi_container = parse(bia_submission.submission_dirpath/"rembi-metadata.yaml")
 
     root_path = f"{bia_submission.submission_dirpath.name}/files"
     bst_submission = rembi_container_to_pagetab(rembi_container, accession_id=accession_id, root_path=root_path)

--- a/bia_agent/tests/test_cli.py
+++ b/bia_agent/tests/test_cli.py
@@ -21,3 +21,26 @@ def test_cli_stdout(rembi_file_path: str, cli_command: str, outfile: str):
     assert result.exit_code == 0
     assert result.stdout is not None  # Ensure some output is produced
     assert result.stdout == Path(outfile).read_text() #Veryify output is equal to files
+
+
+
+
+@pytest.mark.parametrize(
+    "yaml_file_path, json_file_path, cli_command",
+    [
+        ("examples/rembi-metadata.yaml", "examples/rembi-metadata.json", "rembi-to-pagetab"),
+        ("examples/mifa-metadata.yaml", "examples/mifa-metadata.json", "rembi-mifa-to-pagetab"),
+    ],
+)
+def test_json_yaml_produce_same_pagetab(yaml_file_path: str, json_file_path: str, cli_command: str):
+    
+    result_yaml = runner.invoke(app, [cli_command, yaml_file_path, ACCESSION_ID])
+    result_json = runner.invoke(app, [cli_command, json_file_path, ACCESSION_ID])
+
+    assert result_yaml.exit_code == 0
+    assert result_json.exit_code == 0
+
+    assert result_yaml.stdout is not None  # Ensure some output is produced
+    assert result_json.stdout is not None  # Ensure some output is produced
+    
+    assert result_yaml.stdout ==  result_json.stdout #Veryify output is the same with equivalent files

--- a/examples/mifa-metadata.json
+++ b/examples/mifa-metadata.json
@@ -1,0 +1,82 @@
+{
+  "study": {
+    "title": "An annotated fluorescence image dataset for training nuclear segmentation methods",
+    "description": "This dataset contains annotated fluorescent nuclear images of normal or cancer cells from different tissue origins and sample preparation types,  and can be used to train machine-learning based nuclear image segmentation algorithms.\nIt consists of 79 expert-annotated fluorescence images  of immuno and DAPI stained samples containing 7813 nuclei in total.\nIn addition, the dataset is heterogenous in aspects such as type of preparation,  imaging modality, magnification, signal-to-noise ratio and other technical aspects.\nRelevant parameters, e.g. diagnosis, magnification,  signal-to-noise ratio and modality with respect to the type of preparation are provided in the file list.\nThe images are derived from one Schwann cell stroma-rich tissue (from a ganglioneuroblastoma) cryosection (10 images/2773 nuclei), seven neuroblastoma (NB) patients (19 images/931 nuclei), one Wilms patient (1 image/102 nuclei),  two NB cell lines (CLB-Ma, STA-NB10) (8 images/1785 nuclei) and a human keratinocyte cell line (HaCaT) (41 images/2222 nuclei).",
+    "private_until_date": "2024-08-02",
+    "keywords": [
+      "AI",
+      "segmentation",
+      "nucleus",
+      "fluorescence"
+    ],
+    "authors": [
+      {
+        "first_name": "Sabine",
+        "last_name": "Taschner-Mandl",
+        "email": "sabine.taschner@ccri.at",
+        "role": "conceptualization, data acquisition",
+        "orcid": "0000-0002-1439-5301",
+        "affiliation": {
+          "name": "Children's Cancer Research Institute",
+          "address": "Zimmermannplatz 10, 1090 Vienna, Austria"
+        }
+      },
+      {
+        "first_name": "Florian",
+        "last_name": "Kromp",
+        "role": "conceptualization, data acquisition, data annotation, data analysis",
+        "orcid": "0000-0003-4557-5652",
+        "affiliation": {
+          "name": "Children's Cancer Research Institute",
+          "address": "Zimmermannplatz 10, 1090 Vienna, Austria"
+        }
+      }
+    ],
+    "publications": [
+      {
+        "title": "An annotated fluorescence image dataset for training nuclear segmentation methods",
+        "authors": "Florian Kromp, Eva Bozsaky, Fikret Rifatbegovic, Lukas Fischer, Magdalena Ambros, Maria Berneder,  Tamara Weiss, Daria Lazic, Wolfgang Dörr, Allan Hanbury, Klaus Beiske, Peter F. Ambros, Inge M. Ambros & Sabine Taschner-Mandl",
+        "doi": "https://doi.org/10.1038/s41597-020-00608-w",
+        "year": 2020,
+        "pubmed_id": "PMC7419523"
+      }
+    ],
+    "funding": {
+      "funding_statement": "This work was facilitated by an EraSME grant (project TisQuant) under the grant no. 844198 and by a COIN grant (project VISIOMICS) under the grant no. 861750, both grants kindly provided by the Austrian Research Promotion Agency (FFG), and the St. Anna Kinderkrebsforschung.  Partial funding was further provided by BMK, BMDW, and the Province of Upper Austria in the frame of the COMET Programme managed by FFG.",
+      "grant_references": [
+        {
+          "funder": "EraSME",
+          "identifier": 844198
+        }
+      ]
+    },
+    "links": [
+      {
+        "link_url": "https://github.com/perlfloccri/NuclearSegmentationPipeline",
+        "link_description": "Deep Learning models trained with this dataset"
+      }
+    ],
+    "acknowledgements": "We thank Professor Josiah Carberry for useful discussions",
+    "rembi_version": "1.5"
+  },
+  "annotations": {
+    "Segmentation masks": {
+      "annotation_overview": "Segmentations masks of human cell nuclei curated by experts from a model prediction",
+      "annotation_type": [
+        "segmentation_mask"
+      ],
+      "annotation_method": "Nuclei image annotation was performed by students and expert biologists trained by a disease expert.  To accelerate the time consuming process of image annotation, a machine learning-based framework (MLF) was utilized supporting  the process of annotation by learning characteristics of annotation in multiple steps. The MLF annotations result in a coarse annotation  of nuclear contours and have to be refined to serve as ground truth annotation. Therefore, annotated images were exported as  support vector graphic (SVG) files and imported into Adobe Illustrator (AI) CS6. AI enables the visualization of annotated nuclei as polygons  overlaid on the raw nuclear image and provides tools to refine the contours of each nucleus. An expert biologist and disease expert carefully curated  all images by refining polygonal contours and by removing polygons or adding them, if missing. Finally, an expert pathologist was consulted  to revise all image annotations and annotations were curated according to the pathologist's suggestions. In cases where decision finding was difficult,  a majority vote including all experts' suggestions was considered and annotations were corrected accordingly.  Images were exported and converted to Tagged Image File Format (TIFF) files, serving as nuclear masks in the ground truth dataset.  To set a baseline for machine learning-based image segmentation methods and to validate the proposed dataset, 25 nuclei were randomly sampled from  the ground truth annotations for each of the classes, marked on the raw images and presented to two independent experts for image annotation.  Annotation was carried out by a biology expert with long-standing experience in nuclear image annotation, further called annotation expert, and a biologist  with experience in cell morphology and microscopy, further called expert biologist. Nuclei were annotated using SVG-files and Adobe illustrator.  The single-nuclei annotations, described as single-cell annotations within the dataset, can be downloaded along with the dataset.",
+      "annotation_confidence_level": "Curators had between 10 and 15 years of experience in cancer pathology",
+      "annotation_criteria": "\"The annotation of nuclei in tissue sections or tumor touch imprints is challenging and may not be unambiguous due to out-of-focus light or nuclei,  damaged nuclei or nuclei presenting with modified morphology due to the slide preparation procedure. We defined the following criteria to annotate  nuclear images: Only intact nuclei are annotated, even if the nuclear intensity is low in comparison to all other nuclei present. Nuclei have to be in focus.  If parts of a nucleus are out of focus, only the part of the nucleus being in focus is annotated. Nuclear borders have to be annotated as exact as resolution  and blurring allows for. Nuclei are not annotated if their morphology was heavily changed due to the preparation procedure.  Nuclei from dividing cells are annotated as one nucleus unless clear borders can be distinguished between the resulting new nuclei.\"",
+      "annotation_coverage": "All the images in the dataset were annotated"
+    }
+  },
+  "version": {
+    "Segmentation masks": {
+      "version": "v1.1",
+      "timestamp": "2015-03-22T01:49:21",
+      "changes": "The new version of the dataset includes 20 additional annotations (files seg34.tif to seg54.tif)",
+      "previous_version": "v1.0"
+    }
+  }
+}

--- a/examples/rembi-metadata.json
+++ b/examples/rembi-metadata.json
@@ -1,0 +1,110 @@
+{
+    "study": {
+        "title": "Embryonic mice ultrasound volumes with body and brain volume segmentation masks",
+        "description": "A dataset consisting of 231 embryonic mice High Frequency Ultrasound volumes which were acquired in utero and in vivo from pregnant mice. Another submission contains the body and brain volume segmentation masks of these images.",
+        "private_until_date": "2023-05-10",
+        "keywords": [
+            "Image segmentation",
+            "high-frequency ultrasound",
+            "mouse embryo",
+            "volumetric deep learning"
+        ],
+        "authors": [
+            {
+                "first_name": "Ziming",
+                "last_name": "Qiu",
+                "role": "submitter",
+                "affiliation": {
+                    "name": "Department of Electrical and Computer Engineering",
+                    "address": "New York University, New York, USA"
+                }
+            },
+            {
+                "first_name": "Matthew",
+                "last_name": "Hartley",
+                "role": "data curator",
+                "affiliation": {
+                    "name": "European Molecular Biology Laboratory, European Bioinformatics Institute"
+                }
+            }
+        ],
+        "publications": [
+            {
+                "title": "DEEP MOUSE: AN END-TO-END AUTO-CONTEXT REFINEMENT FRAMEWORK FOR BRAIN VENTRICLE & BODY SEGMENTATION IN EMBRYONIC MICE ULTRASOUND VOLUMES.",
+                "authors": "Qiu Z, Das W, Wang C, Langerman J, Nair N, Aristizábal O, Mamou J, Turnbull DH, Ketterling JA, Wang Y",
+                "doi": "https://doi.org/10.1109/isbi45749.2020.9098387",
+                "year": "2020",
+                "pubmed_id": "PMC7768981"
+            }
+        ],
+        "links": [
+            {
+                "link_url": "https://www.ebi.ac.uk/biostudies/bioimages/studies/S-BSST401",
+                "link_description": "Original submission (not curated)"
+            },
+            {
+                "link_url": "https://github.com/BioImage-Archive",
+                "link_description": "Github link for the Image Analysis"
+            }
+        ],
+        "rembi_version": "1.5"
+    },
+    "biosamples": {
+        "In utero mouse embryos": {
+            "organism": {
+                "scientific_name": "mus musculus",
+                "common_name": "mouse",
+                "ncbi_taxon": "NCBI:txid10090"
+            },
+            "biological_entity": "mouse embryo volumes",
+            "description": "mouse embryo volumes which were acquired in utero and in vivo from pregnant mice (10-14.5 days after mating)",
+            "intrinsic_variables": [
+                "Homozygous GFP integration into mitotic genes"
+            ]
+        }
+    },
+    "specimens": {
+        "HFU sample preparation": {
+            "sample_preparation": "Unknown"
+        }
+    },
+    "acquisitions": {
+        "Ultrasound Image Acquisition": {
+            "imaging_method": {
+                "value": "Echography",
+                "ontology_id": "http://edamontology.org/topic_3954",
+                "ontology_name": "EDAM"
+            },
+            "imaging_instrument": "High frequency ultrasound 5-element 40-MHz annular array",
+            "image_acquisition_parameters": "The dimensions of the HFU volumes vary from 150 x 161 x 81 to 210 x 281 x 282 voxels and the voxel size is 50 x 50 x 50 μm"
+        }
+    },
+    "correlations": {
+        "Image Correlation": {
+            "spatial_and_temporal_alignment": "An alignment algorithm is used.",
+            "fiducials_used": "Fiducials were randomly dropped into sample",
+            "transformation_matrix": "Matrix is provided as a table."
+        }
+    },
+    "analysis": {
+        "Image Analysis": {
+            "analysis_overview": "Analysis is done with custom tensorflow models. The code is on github. Linked in Links field."
+        }
+    },
+    "study_component": {
+        "experiment1": {
+            "name": "Ultrasound images",
+            "description": "Ultrasound images and correlation and analysis",
+            "rembi_version": "1.5"
+        }
+    },
+    "associations": {
+        "experiment1": {
+            "biosample_id": "In utero mouse embryos",
+            "specimen_id": "HFU sample preparation",
+            "acquisition_id": "Ultrasound Image Acquisition",
+            "correlation_id": "Image Correlation",
+            "analysis_id": "Image Analysis"
+        }
+    }
+}


### PR DESCRIPTION
Modified CLI to parse json as well as yaml. This is currently based on the file extension, but could instead try importing some new library to check the file type instead if we need to not enforce that the files end with .json or .yaml.

Added a test to check that equivalent json and yaml produce the same output.

Also updated the (generate bst) submission code to use the more generic parsing of both yaml and json.