### PR TITLE
validate required metadata before pagetab generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Converting MIFA annotations YAML to PageTab
 
 Using poetry:
 
-    poetry run bia-agent rembi-mifa-to-pagetab examples/mifa-metadata.yaml S-BIADXXX
+    poetry run bia-agent mifa-to-pagetab examples/mifa-metadata.yaml S-BIADXXX
 
 Converting giga-EM spreadsheet to PageTab
 -------------------------------------------

--- a/bia_agent/cli.py
+++ b/bia_agent/cli.py
@@ -10,7 +10,7 @@ from .biostudies import Submission
 from .files import FileCollection
 from .submission import submission_from_dirpath, generate_bst_submission, generate_filelists
 from .transfer import copy_single_file, copy_all, verify
-from .rembi import parse
+from .rembi import REMBIValidationError, parse
 from .rembi2pagetab import rembi_container_to_pagetab
 from .mifa2pagetab import rembi_mifa_container_to_pagetab, mifa_container_to_pagetab
 from .gigaEM2pagetab import build_container
@@ -24,6 +24,11 @@ app = typer.Typer()
 class OutputFormat(str, Enum):
     TSV = 'tsv'
     JSON = 'json'
+
+
+def _exit_invalid_metadata(error):
+    typer.echo(f"Invalid metadata:\n{error}", err=True)
+    raise typer.Exit(code=1)
 
 
 @app.command()
@@ -134,9 +139,11 @@ def rembi_to_pagetab(
         typer.Option("--format", "-f", help="Output format", case_sensitive=False)
     ] = OutputFormat.TSV,
 ):
-    rembi_container = parse(rembi_fpath)
-
-    bst_submission = rembi_container_to_pagetab(rembi_container, accession_id=accession_id, root_path=None)
+    try:
+        rembi_container = parse(rembi_fpath)
+        bst_submission = rembi_container_to_pagetab(rembi_container, accession_id=accession_id, root_path=None)
+    except REMBIValidationError as e:
+        _exit_invalid_metadata(e)
 
     if outputFormat == OutputFormat.TSV:
         print(bst_submission.as_tsv())
@@ -153,9 +160,11 @@ def rembi_mifa_to_pagetab(
         typer.Option("--format", "-f", help="Output format", case_sensitive=False)
     ] = OutputFormat.TSV,
 ):
-    rembi_mifa_container = parse(rembi_mifa_fpath)
-
-    bst_submission = rembi_mifa_container_to_pagetab(rembi_mifa_container, accession_id=accession_id, root_path=None)
+    try:
+        rembi_mifa_container = parse(rembi_mifa_fpath)
+        bst_submission = rembi_mifa_container_to_pagetab(rembi_mifa_container, accession_id=accession_id, root_path=None)
+    except REMBIValidationError as e:
+        _exit_invalid_metadata(e)
     
     if outputFormat == OutputFormat.TSV:
         print(bst_submission.as_tsv())
@@ -171,9 +180,11 @@ def mifa_to_pagetab(
         typer.Option("--format", "-f", help="Output format", case_sensitive=False)
     ] = OutputFormat.TSV,
 ):
-    mifa_container = parse(mifa_fpath)
-
-    bst_submission = mifa_container_to_pagetab(mifa_container, accession_id=accession_id, root_path=None)
+    try:
+        mifa_container = parse(mifa_fpath)
+        bst_submission = mifa_container_to_pagetab(mifa_container, accession_id=accession_id, root_path=None)
+    except REMBIValidationError as e:
+        _exit_invalid_metadata(e)
     
     if outputFormat == OutputFormat.TSV:
         print(bst_submission.as_tsv())
@@ -192,9 +203,11 @@ def gigaem_to_pagetab(
     ] = OutputFormat.TSV,
 ):
 
-    rembi_mifa_container = build_container(study_path, im_path, ann_path)
-
-    bst_submission = rembi_mifa_container_to_pagetab(rembi_mifa_container, accession_id=accession_id, root_path=None)
+    try:
+        rembi_mifa_container = build_container(study_path, im_path, ann_path)
+        bst_submission = rembi_mifa_container_to_pagetab(rembi_mifa_container, accession_id=accession_id, root_path=None)
+    except REMBIValidationError as e:
+        _exit_invalid_metadata(e)
     
     if outputFormat == OutputFormat.TSV:
         print(bst_submission.as_tsv())

--- a/bia_agent/gigaEM2pagetab.py
+++ b/bia_agent/gigaEM2pagetab.py
@@ -1,5 +1,7 @@
 import pandas as pd
-from .rembi import REMBIContainer
+from pydantic import ValidationError
+
+from .rembi import REMBIContainer, REMBIValidationError
 
 study_mapping = {
     # simple fields (take first non-null value)
@@ -331,7 +333,10 @@ def build_container(study_path, im_path, ann_path):
 
     data = prune_empty(data) # remove some cases where there are empty cells
 
-    container = REMBIContainer.parse_obj(data)
+    try:
+        container = REMBIContainer.parse_obj(data)
+    except ValidationError as e:
+        raise REMBIValidationError(str(e)) from e
     
     return container
 

--- a/bia_agent/mifa2pagetab.py
+++ b/bia_agent/mifa2pagetab.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from .biostudies import Attribute, Submission
-from .rembi import REMBIContainer
+from .rembi import REMBIContainer, validate_mifa_metadata, validate_rembi_mifa_metadata
 
 from .utils import (rembi_study_to_pagetab_submission,
                     biosample_to_pagetab_section,
@@ -16,6 +16,7 @@ from .utils import (rembi_study_to_pagetab_submission,
 
 def rembi_mifa_container_to_pagetab(container: REMBIContainer, accession_id: Optional[str], root_path: Optional[str]) -> Submission:
     """Convert a REMBI + MIFA Container object into a PageTab submission."""
+    validate_rembi_mifa_metadata(container)
 
     submission = rembi_study_to_pagetab_submission(container.study, template=ST_MIFA_TEMPLATE_VERSION, accession_id=accession_id)
 
@@ -39,14 +40,23 @@ def rembi_mifa_container_to_pagetab(container: REMBIContainer, accession_id: Opt
     )
 
     ann_section = [
-        mifa_annotations_to_pagetab_section(annotations=ann_object, version=v_object, title=ann_id, suffix=n)
-        for n, ((ann_id, ann_object),(v_id, v_object)) in enumerate(zip(container.annotations.items(),container.version.items()), start=1)
+        mifa_annotations_to_pagetab_section(
+            annotations=ann_object,
+            version=container.version.get(ann_id),
+            title=ann_id,
+            suffix=n,
+        )
+        for n, (ann_id, ann_object) in enumerate(container.annotations.items(), start=1)
     ]
     submission.section.subsections += ann_section
 
     sc_section = [
-        study_component_to_pagetab_section(study_component=sc_object, associations=a_object, suffix=n)
-        for n, ((sc_id, sc_object),(a_id, a_object)) in enumerate(zip(container.study_component.items(),container.associations.items()), start=1)
+        study_component_to_pagetab_section(
+            study_component=sc_object,
+            associations=container.associations[sc_id],
+            suffix=n,
+        )
+        for n, (sc_id, sc_object) in enumerate(container.study_component.items(), start=1)
     ]
 
     submission.section.subsections += sc_section
@@ -55,6 +65,7 @@ def rembi_mifa_container_to_pagetab(container: REMBIContainer, accession_id: Opt
 
 def mifa_container_to_pagetab(container: REMBIContainer, accession_id: Optional[str], root_path: Optional[str]) -> Submission:
     """Convert a MIFA Container object into a PageTab submission."""
+    validate_mifa_metadata(container)
 
     submission = rembi_study_to_pagetab_submission(container.study, template=ST_MIFA_TEMPLATE_VERSION, accession_id=accession_id)
 
@@ -62,8 +73,13 @@ def mifa_container_to_pagetab(container: REMBIContainer, accession_id: Optional[
         submission.attributes.append(Attribute(name="RootPath", value=root_path))
 
     ann_section = [
-        mifa_annotations_to_pagetab_section(annotations=ann_object, version=v_object, title=ann_id, suffix=n)
-        for n, ((ann_id, ann_object),(v_id, v_object)) in enumerate(zip(container.annotations.items(),container.version.items()), start=1)
+        mifa_annotations_to_pagetab_section(
+            annotations=ann_object,
+            version=container.version.get(ann_id),
+            title=ann_id,
+            suffix=n,
+        )
+        for n, (ann_id, ann_object) in enumerate(container.annotations.items(), start=1)
     ]
     submission.section.subsections += ann_section
 

--- a/bia_agent/rembi.py
+++ b/bia_agent/rembi.py
@@ -1,6 +1,6 @@
 from typing import Dict
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 from ruamel.yaml import YAML
 from ruamel.yaml.scanner import ScannerError
 from ruamel.yaml.parser import ParserError
@@ -37,6 +37,155 @@ class REMBIContainer(BaseModel):
     study_component: Dict[str, StudyComponent] = {}
 
 
+class REMBIValidationError(ValueError):
+    pass
+
+
+STUDY_REQUIRED_FIELDS = (
+    "title",
+    "description",
+    "private_until_date",
+    "keywords",
+    "authors",
+    "rembi_version",
+)
+
+REMBI_REQUIRED_SECTIONS = (
+    "biosamples",
+    "specimens",
+    "acquisitions",
+    "study_component",
+    "associations",
+)
+
+MIFA_REQUIRED_SECTIONS = (
+    "annotations",
+)
+
+MIFA_REQUIRED_ANNOTATION_FIELDS = (
+    "annotation_overview",
+    "annotation_type",
+    "annotation_method",
+)
+
+ASSOCIATION_TARGETS = (
+    ("biosample_id", "biosamples", "biosample"),
+    ("specimen_id", "specimens", "specimen"),
+    ("acquisition_id", "acquisitions", "acquisition"),
+    ("correlation_id", "correlations", "correlation"),
+    ("analysis_id", "analysis", "analysis"),
+)
+
+
+def validate_rembi_metadata(container: REMBIContainer):
+    errors = []
+    _validate_required_study_fields(container, errors)
+    _validate_required_sections(container, REMBI_REQUIRED_SECTIONS, errors)
+    _validate_study_component_associations(container, errors)
+    _validate_association_targets(container, errors)
+    _raise_validation_errors(errors)
+
+
+def validate_mifa_metadata(container: REMBIContainer):
+    errors = []
+    _validate_required_study_fields(container, errors)
+    _validate_required_sections(container, MIFA_REQUIRED_SECTIONS, errors)
+    _validate_mifa_fields(container, errors)
+    _validate_annotation_versions(container, errors)
+    _raise_validation_errors(errors)
+
+
+def validate_rembi_mifa_metadata(container: REMBIContainer):
+    errors = []
+    _validate_required_study_fields(container, errors)
+    _validate_required_sections(container, REMBI_REQUIRED_SECTIONS + MIFA_REQUIRED_SECTIONS, errors)
+    _validate_study_component_associations(container, errors)
+    _validate_association_targets(container, errors)
+    _validate_mifa_fields(container, errors)
+    _validate_annotation_versions(container, errors)
+    _raise_validation_errors(errors)
+
+
+def _validate_required_study_fields(container, errors):
+    missing_fields = [
+        f"study.{field_name}"
+        for field_name in STUDY_REQUIRED_FIELDS
+        if _is_empty_required_value(getattr(container.study, field_name, None))
+    ]
+
+    if missing_fields:
+        errors.append("Missing or empty required study field(s): " + ", ".join(missing_fields))
+
+
+def _validate_required_sections(container, section_names, errors):
+    missing_sections = [
+        section_name
+        for section_name in section_names
+        if not getattr(container, section_name)
+    ]
+
+    if missing_sections:
+        errors.append("Missing required section(s): " + ", ".join(missing_sections))
+
+
+def _validate_study_component_associations(container, errors):
+    study_component_ids = set(container.study_component)
+    association_ids = set(container.associations)
+
+    for study_component_id in sorted(study_component_ids - association_ids):
+        errors.append(f"Study component '{study_component_id}' is missing a matching association")
+
+    for association_id in sorted(association_ids - study_component_ids):
+        errors.append(f"Association '{association_id}' does not match a study component")
+
+
+def _validate_association_targets(container, errors):
+    for association_id, association in container.associations.items():
+        for field_name, section_name, label in ASSOCIATION_TARGETS:
+            target_id = getattr(association, field_name)
+            if not target_id:
+                continue
+
+            target_section = getattr(container, section_name)
+            if target_id not in target_section:
+                errors.append(f"Association '{association_id}' references missing {label} '{target_id}'")
+
+
+def _validate_mifa_fields(container, errors):
+    for annotation_id, annotation in container.annotations.items():
+        missing_fields = [
+            f"annotations.{annotation_id}.{field_name}"
+            for field_name in MIFA_REQUIRED_ANNOTATION_FIELDS
+            if _is_empty_required_value(getattr(annotation, field_name, None))
+        ]
+
+        if missing_fields:
+            errors.append("Missing or empty required MIFA field(s): " + ", ".join(missing_fields))
+
+
+def _validate_annotation_versions(container, errors):
+    annotation_ids = set(container.annotations)
+    version_ids = set(container.version)
+
+    for version_id in sorted(version_ids - annotation_ids):
+        errors.append(f"Version '{version_id}' does not match an annotation")
+
+
+def _is_empty_required_value(value):
+    if value is None:
+        return True
+    if isinstance(value, str):
+        return not value.strip()
+    if isinstance(value, (list, tuple, dict, set)):
+        return not value
+    return False
+
+
+def _raise_validation_errors(errors):
+    if errors:
+        raise REMBIValidationError("\n".join(errors))
+
+
 def parse(fpath):
     if not Path(fpath).is_file():
         exit(f"{fpath} is not a file")
@@ -60,7 +209,10 @@ def parse_yaml(fpath):
     except (ScannerError, ParserError) as e:
         exit(f"Invalid YAML: {str(e)}")
 
-    return REMBIContainer.parse_obj(raw_object)
+    try:
+        return REMBIContainer.parse_obj(raw_object)
+    except ValidationError as e:
+        raise REMBIValidationError(str(e)) from e
 
 def parse_json(fpath):
 
@@ -70,4 +222,7 @@ def parse_json(fpath):
     except json.JSONDecodeError as e:
         exit(f"Invalid JSON: {str(e)}")
 
-    return REMBIContainer.parse_obj(raw_object)
+    try:
+        return REMBIContainer.parse_obj(raw_object)
+    except ValidationError as e:
+        raise REMBIValidationError(str(e)) from e

--- a/bia_agent/rembi2pagetab.py
+++ b/bia_agent/rembi2pagetab.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from .biostudies import Attribute, Submission
-from .rembi import REMBIContainer
+from .rembi import REMBIContainer, validate_rembi_metadata
 from .utils import (rembi_study_to_pagetab_submission,
                     biosample_to_pagetab_section,
                     specimen_to_pagetab_section,
@@ -15,6 +15,7 @@ from .utils import (rembi_study_to_pagetab_submission,
 
 def rembi_container_to_pagetab(container: REMBIContainer, accession_id: Optional[str], root_path: Optional[str]) -> Submission:
     """Convert a REMBI Container object into a PageTab submission."""
+    validate_rembi_metadata(container)
 
     submission = rembi_study_to_pagetab_submission(container.study, template=ST_REMBI_TEMPLATE_VERSION, accession_id=accession_id)
 
@@ -39,8 +40,8 @@ def rembi_container_to_pagetab(container: REMBIContainer, accession_id: Optional
     )
 
     sc_section = [
-        study_component_to_pagetab_section(sc_object, a_object, suffix=n)
-        for n, ((sc_id, sc_object),(a_id, a_object)) in enumerate(zip(container.study_component.items(),container.associations.items()), start=1)
+        study_component_to_pagetab_section(sc_object, container.associations[sc_id], suffix=n)
+        for n, (sc_id, sc_object) in enumerate(container.study_component.items(), start=1)
     ]
 
     submission.section.subsections += sc_section

--- a/bia_agent/tests/test_cli.py
+++ b/bia_agent/tests/test_cli.py
@@ -1,17 +1,37 @@
 from typer.testing import CliRunner
 from bia_agent.cli import app, OutputFormat
 from pathlib import Path
+from ruamel.yaml import YAML
 import pytest
 import json
 runner = CliRunner()
 
 ACCESSION_ID="S-BIADXXX"
 
+
+def write_yaml_with_mutation(tmp_path, source_fpath, mutate):
+    yaml = YAML()
+
+    with open(source_fpath) as fh:
+        raw_object = yaml.load(fh)
+
+    mutate(raw_object)
+
+    output_fpath = tmp_path / Path(source_fpath).name
+    with output_fpath.open("w") as fh:
+        yaml.dump(raw_object, fh)
+
+    return output_fpath
+
+
+def result_text(result):
+    return result.output
+
 @pytest.mark.parametrize(
     "rembi_file_path, cli_command, outfile",
     [
         ("examples/rembi-metadata.yaml", "rembi-to-pagetab", "examples/output/rembi-metadata_rembi-to-pagetab.tsv"),
-        ("examples/mifa-metadata.yaml", "rembi-mifa-to-pagetab", "examples/output/mifa-metadata_rembi-mifa-to-pagetab.tsv"),
+        ("examples/mifa-metadata.yaml", "mifa-to-pagetab", "examples/output/mifa-metadata_rembi-mifa-to-pagetab.tsv"),
         ("examples/rembi-metadata-with-mifa.yaml", "rembi-mifa-to-pagetab", "examples/output/rembi-metadata-with-mifa_rembi-mifa-to-pagetab.tsv")
     ],
 )
@@ -30,7 +50,7 @@ def test_cli_tsvout(rembi_file_path: str, cli_command: str, outfile: str):
     "yaml_file_path, json_file_path, cli_command",
     [
         ("examples/rembi-metadata.yaml", "examples/rembi-metadata.json", "rembi-to-pagetab"),
-        ("examples/mifa-metadata.yaml", "examples/mifa-metadata.json", "rembi-mifa-to-pagetab"),
+        ("examples/mifa-metadata.yaml", "examples/mifa-metadata.json", "mifa-to-pagetab"),
     ],
 )
 def test_json_yaml_produce_same_pagetab(yaml_file_path: str, json_file_path: str, cli_command: str):
@@ -68,3 +88,73 @@ def test_cli_json(rembi_file_path: str, cli_command: str, format_option: str, ou
     #Verify output json is equivalent
     assert json.loads(result.stdout) == json.loads(Path(outfile).read_text())
 
+
+def test_rembi_cli_rejects_missing_required_section(tmp_path):
+    input_fpath = write_yaml_with_mutation(
+        tmp_path,
+        "examples/rembi-metadata.yaml",
+        lambda raw_object: raw_object.pop("biosamples"),
+    )
+
+    result = runner.invoke(app, ["rembi-to-pagetab", str(input_fpath), ACCESSION_ID])
+
+    assert result.exit_code == 1
+    assert "Missing required section(s): biosamples" in result_text(result)
+
+
+def test_rembi_mifa_cli_rejects_missing_mifa_annotations(tmp_path):
+    input_fpath = write_yaml_with_mutation(
+        tmp_path,
+        "examples/rembi-metadata-with-mifa.yaml",
+        lambda raw_object: raw_object.pop("annotations"),
+    )
+
+    result = runner.invoke(app, ["rembi-mifa-to-pagetab", str(input_fpath), ACCESSION_ID])
+
+    assert result.exit_code == 1
+    assert "Missing required section(s): annotations" in result_text(result)
+
+
+def test_mifa_cli_allows_missing_version_section(tmp_path):
+    input_fpath = write_yaml_with_mutation(
+        tmp_path,
+        "examples/mifa-metadata.yaml",
+        lambda raw_object: raw_object.pop("version"),
+    )
+
+    result = runner.invoke(app, ["mifa-to-pagetab", str(input_fpath), ACCESSION_ID])
+
+    assert result.exit_code == 0
+    assert "Annotation version" not in result.stdout
+
+
+def test_rembi_cli_rejects_missing_association_target(tmp_path):
+    def remove_referenced_biosample(raw_object):
+        raw_object["biosamples"].pop("In utero mouse embryos")
+
+    input_fpath = write_yaml_with_mutation(
+        tmp_path,
+        "examples/rembi-metadata.yaml",
+        remove_referenced_biosample,
+    )
+
+    result = runner.invoke(app, ["rembi-to-pagetab", str(input_fpath), ACCESSION_ID])
+
+    assert result.exit_code == 1
+    assert "Association 'experiment1' references missing biosample 'In utero mouse embryos'" in result_text(result)
+
+
+def test_rembi_cli_rejects_empty_required_study_field(tmp_path):
+    def empty_required_field(raw_object):
+        raw_object["study"]["description"] = ""
+
+    input_fpath = write_yaml_with_mutation(
+        tmp_path,
+        "examples/rembi-metadata.yaml",
+        empty_required_field,
+    )
+
+    result = runner.invoke(app, ["rembi-to-pagetab", str(input_fpath), ACCESSION_ID])
+
+    assert result.exit_code == 1
+    assert "Missing or empty required study field(s): study.description" in result_text(result)

--- a/bia_agent/utils.py
+++ b/bia_agent/utils.py
@@ -456,7 +456,7 @@ def create_annotations_section(name: str, description: str, file_list_fname: str
 
     return annotations
 
-def mifa_annotations_to_pagetab_section(annotations: Annotations, version: Version, title: str, suffix=1) -> Section:
+def mifa_annotations_to_pagetab_section(annotations: Annotations, version: Optional[Version], title: str, suffix=1) -> Section:
 
     annotations_section = Section(
         type="Annotations",
@@ -479,8 +479,11 @@ def mifa_annotations_to_pagetab_section(annotations: Annotations, version: Versi
                 value=annotations.annotation_method
             )
         ],
-        subsections=[mifa_version_to_pagetab_section(version)]
+        subsections=[]
     )
+
+    if version is not None:
+        annotations_section.subsections.append(mifa_version_to_pagetab_section(version))
     
     append_if_not_none(annotations_section.attributes, "Annotation Confidence Level", annotations.annotation_confidence_level)
     append_if_not_none(annotations_section.attributes, "Annotation Criteria", annotations.annotation_criteria)

--- a/yaml-templates/rembi-mifa-metadata-template.yaml
+++ b/yaml-templates/rembi-mifa-metadata-template.yaml
@@ -71,8 +71,8 @@ annotations: # Optional section - Delete the whole section if not relevant
     annotation_coverage: # Optional # If the dataset is not completely annotated, which images from the dataset were annotated, and what percentage of the data has been annotated from what is available?
 version: # Optional section if no annotations section exists 
   Annotations: # Edit this according to the name used in the annotations section above
-    version: # Required # Unique version number for the annotations
-    timestamp: # Required # Date and time when the annotations version was created
+    version: # Optional # Unique version number for the annotations
+    timestamp: # Optional # Date and time when the annotations version was created
     changes: # Optional # Textual description of changes compared to previous version
     previous_version: # Optional # Pointer to previous annotations version
 study_component: # Add more study components by repeating the block below (change title to 'Study component 2', etc.). You will need an associations block (below) per study component


### PR DESCRIPTION
Implemented validation for required metadata before PageTab generation.

Changes include:

- Added explicit validation for required study fields: title, description, private_until_date, keywords, authors, and rembi_version.
- Added validation for required REMBI sections: biosamples, specimens, acquisitions, study_component, and associations.
- Added validation for required MIFA annotations. I changed MIFA version to be optional as we don't handle that currently on our system.
- Added checks that study components and associations match by ID.
- Added checks that associations reference existing biosamples, specimens, acquisitions, correlations, and analysis sections.
- To be user friendly invalid metadata exits cleanly with an Invalid metadata message.
- Updated the MIFA-only README/test command to use mifa-to-pagetab.
- Added  tests for missing required sections, invalid association references, empty required study fields, and optional MIFA version handling.